### PR TITLE
Feature/make aws optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
 rvm:
-- 1.9.3
 - 2.1.0
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.1.0
 - 1.9.3
+- 2.1.0
 script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ node['ngrokd']['log'] = '/var/log/ngrokd.log' # path for ngrok to log to. stdout
 
 ## Secrets
 
-A SSL certificate and matching private key are required. These are stored in an Amazon S3 bucket and retrieved via [Citadel](https://github.com/poise/citadel), as such IAM Roles (if running the server in EC2) or AWS credentials are required.
+To use the install_certs recipe, an SSL certificate and matching private key are required. These are stored in an Amazon S3 bucket and retrieved via [Citadel](https://github.com/poise/citadel), as such IAM Roles (if running the server in EC2) or AWS credentials are required.
 Bucket should also be specified. See Citadel's docs for more information.
 
+If you do not wish to install the SSL certificate and key from AWS, you can supply the certs any other way you see fit, just use the default recipe.
 
 ## Usage
 
-### ngrokd::default
+### ngrokd-cookbook::default
 
 Include `ngrokd` in your node's `run_list`:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+#^syntaxBOX detection
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,3 +3,5 @@ default['ngrokd']['path'] = '/etc/ngrokd'
 default['ngrokd']['tlskey'] = 'tls.key'
 default['ngrokd']['tlscrt'] = 'tls.crt'
 default['ngrokd']['log'] = '/var/log/ngrokd.log'
+# Set to false if you don't want to source your tls cert from AWS
+default['ngrokd']['source_aws'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,5 +3,3 @@ default['ngrokd']['path'] = '/etc/ngrokd'
 default['ngrokd']['tlskey'] = 'tls.key'
 default['ngrokd']['tlscrt'] = 'tls.crt'
 default['ngrokd']['log'] = '/var/log/ngrokd.log'
-# Set to false if you don't want to source your tls cert from AWS
-default['ngrokd']['source_aws'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,12 @@
-name 'ngrokd'
+name 'ngrokd-cookbook'
 maintainer 'Robert Coleman'
 maintainer_email 'github@robert.net.nz'
 license 'MIT'
 description 'Installs/Configures ngrokd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.2'
+recipe 'default', 'Installs ngrok-server with /etc directory and upstart config'
+recipe 'install_certs', 'Installs tls certs from AWS S3 via the citadel cookbook'
 
 supports 'ubuntu'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,20 +2,22 @@ package 'ngrok-server'
 
 directory node['ngrokd']['path']
 
-tlskey_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlskey'])
-file tlskey_path do
-  owner 'root'
-  group 'root'
-  mode '600'
-  content citadel['tls.key']
-end
+if node['ngrokd']['source_aws']
+  tlskey_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlskey'])
+  file tlskey_path do
+    owner 'root'
+    group 'root'
+    mode '600'
+    content citadel['tls.key']
+  end
 
-tlscrt_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlscrt'])
-file tlscrt_path do
-  owner 'root'
-  group 'root'
-  mode '600'
-  content citadel['tls.crt']
+  tlscrt_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlscrt'])
+  file tlscrt_path do
+    owner 'root'
+    group 'root'
+    mode '600'
+    content citadel['tls.crt']
+  end
 end
 
 template '/etc/init/ngrokd.conf' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,23 +2,8 @@ package 'ngrok-server'
 
 directory node['ngrokd']['path']
 
-if node['ngrokd']['source_aws']
-  tlskey_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlskey'])
-  file tlskey_path do
-    owner 'root'
-    group 'root'
-    mode '600'
-    content citadel['tls.key']
-  end
-
-  tlscrt_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlscrt'])
-  file tlscrt_path do
-    owner 'root'
-    group 'root'
-    mode '600'
-    content citadel['tls.crt']
-  end
-end
+tlscrt_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlscrt'])
+tlskey_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlskey'])
 
 template '/etc/init/ngrokd.conf' do
   source 'ngrokd.upstart.conf.erb'

--- a/recipes/install_certs.rb
+++ b/recipes/install_certs.rb
@@ -1,0 +1,17 @@
+include_recipe 'ngrokd-cookbook::default'
+
+tlskey_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlskey'])
+file tlskey_path do
+  owner 'root'
+  group 'root'
+  mode '600'
+  content citadel['tls.key']
+end
+
+tlscrt_path = ::File.join(node['ngrokd']['path'], node['ngrokd']['tlscrt'])
+file tlscrt_path do
+  owner 'root'
+  group 'root'
+  mode '600'
+  content citadel['tls.crt']
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,67 +1,24 @@
 require_relative '../../spec_helper'
 
-describe 'ngrokd::default' do
-  context 'source tls certificates from AWS' do
-    let(:chef_run) do
-      ChefSpec::Runner.new do |node|
-        node.set['citadel']['access_key_id'] = 'foo'
-        node.set['citadel']['secret_access_key'] = 'bar'
-        node.set['citadel']['bucket'] = 'fake-s3-bucket'
-        node.set['ngrokd']['source_aws'] = true
-      end.converge(described_recipe)
-    end
-
-    it 'installs ngrok-server' do
-      expect(chef_run).to install_package('ngrok-server')
-    end
-
-    it 'creates ngrokd directory' do
-      expect(chef_run).to create_directory('/etc/ngrokd')
-    end
-
-    it 'creates tls.crt' do
-      expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
-    end
-
-    it 'creates tls.key' do
-      expect(chef_run).to render_file('/etc/ngrokd/tls.key')
-    end
-
-    it 'creates ngrokd upstart conf' do
-      expect(chef_run).to create_template('/etc/init/ngrokd.conf')
-    end
-
-    it 'enables and starts ngrokd service' do
-      expect(chef_run).to enable_service('ngrokd')
-      expect(chef_run).to start_service('ngrokd')
-    end
+describe 'ngrokd-cookbook::default' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.converge(described_recipe)
   end
 
-  context 'do not source tls certificates from AWS' do
-    let(:chef_run) do
-      ChefSpec::Runner.new do |node|
-        node.set['citadel']['access_key_id'] = 'foo'
-        node.set['citadel']['secret_access_key'] = 'bar'
-        node.set['citadel']['bucket'] = 'fake-s3-bucket'
-        node.set['ngrokd']['source_aws'] = false
-      end.converge(described_recipe)
-    end
+  it 'installs ngrok-server' do
+    expect(chef_run).to install_package('ngrok-server')
+  end
 
-    it 'installs ngrok-server' do
-      expect(chef_run).to install_package('ngrok-server')
-    end
+  it 'creates ngrokd directory' do
+    expect(chef_run).to create_directory('/etc/ngrokd')
+  end
 
-    it 'creates ngrokd directory' do
-      expect(chef_run).to create_directory('/etc/ngrokd')
-    end
+  it 'creates ngrokd upstart conf' do
+    expect(chef_run).to create_template('/etc/init/ngrokd.conf')
+  end
 
-    it 'creates ngrokd upstart conf' do
-      expect(chef_run).to create_template('/etc/init/ngrokd.conf')
-    end
-
-    it 'enables and starts ngrokd service' do
-      expect(chef_run).to enable_service('ngrokd')
-      expect(chef_run).to start_service('ngrokd')
-    end
+  it 'enables and starts ngrokd service' do
+    expect(chef_run).to enable_service('ngrokd')
+    expect(chef_run).to start_service('ngrokd')
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 describe 'ngrokd::default' do
   context 'source tls certificates from AWS' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new do |node|
+      ChefSpec::Runner.new do |node|
         node.set['citadel']['access_key_id'] = 'foo'
         node.set['citadel']['secret_access_key'] = 'bar'
         node.set['citadel']['bucket'] = 'fake-s3-bucket'
@@ -39,7 +39,7 @@ describe 'ngrokd::default' do
 
   context 'do not source tls certificates from AWS' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new do |node|
+      ChefSpec::Runner.new do |node|
         node.set['citadel']['access_key_id'] = 'foo'
         node.set['citadel']['secret_access_key'] = 'bar'
         node.set['citadel']['bucket'] = 'fake-s3-bucket'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,46 +1,67 @@
 require_relative '../../spec_helper'
 
 describe 'ngrokd::default' do
-  let(:chef_run) do
-    ChefSpec::Runner.new do |node|
-      node.set['ngrokd']['domain'] = 'example.com'
-      node.set['ngrokd']['source_aws'] = false
-    end.converge(described_recipe)
-  end
-
-  it 'installs ngrok-server' do
-    expect(chef_run).to install_package('ngrok-server')
-  end
-
-  it 'creates ngrokd directory' do
-    expect(chef_run).to create_directory('/etc/ngrokd')
-  end
-
-  context 'tls certs come from AWS-S3' do
+  context 'source tls certificates from AWS' do
     let(:chef_run) do
-      ChefSpec::Runner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.set['citadel']['access_key_id'] = 'foo'
         node.set['citadel']['secret_access_key'] = 'bar'
         node.set['citadel']['bucket'] = 'fake-s3-bucket'
         node.set['ngrokd']['source_aws'] = true
       end.converge(described_recipe)
+    end
 
-      it 'creates tls.crt' do
-        expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
-      end
+    it 'installs ngrok-server' do
+      expect(chef_run).to install_package('ngrok-server')
+    end
 
-      it 'creates tls.key' do
-        expect(chef_run).to render_file('/etc/ngrokd/tls.key')
-      end
+    it 'creates ngrokd directory' do
+      expect(chef_run).to create_directory('/etc/ngrokd')
+    end
+
+    it 'creates tls.crt' do
+      expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
+    end
+
+    it 'creates tls.key' do
+      expect(chef_run).to render_file('/etc/ngrokd/tls.key')
+    end
+
+    it 'creates ngrokd upstart conf' do
+      expect(chef_run).to create_template('/etc/init/ngrokd.conf')
+    end
+
+    it 'enables and starts ngrokd service' do
+      expect(chef_run).to enable_service('ngrokd')
+      expect(chef_run).to start_service('ngrokd')
     end
   end
 
-  it 'creates ngrokd upstart conf' do
-    expect(chef_run).to create_template('/etc/init/ngrokd.conf')
-  end
+  context 'do not source tls certificates from AWS' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['citadel']['access_key_id'] = 'foo'
+        node.set['citadel']['secret_access_key'] = 'bar'
+        node.set['citadel']['bucket'] = 'fake-s3-bucket'
+        node.set['ngrokd']['source_aws'] = false
+      end.converge(described_recipe)
+    end
 
-  it 'enables and starts ngrokd service' do
-    expect(chef_run).to enable_service('ngrokd')
-    expect(chef_run).to start_service('ngrokd')
+    it 'installs ngrok-server' do
+      expect(chef_run).to install_package('ngrok-server')
+    end
+
+    it 'creates ngrokd directory' do
+      expect(chef_run).to create_directory('/etc/ngrokd')
+    end
+
+    it 'creates ngrokd upstart conf' do
+      expect(chef_run).to create_template('/etc/init/ngrokd.conf')
+    end
+
+    it 'enables and starts ngrokd service' do
+      expect(chef_run).to enable_service('ngrokd')
+      expect(chef_run).to start_service('ngrokd')
+    end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,10 +3,8 @@ require_relative '../../spec_helper'
 describe 'ngrokd::default' do
   let(:chef_run) do
     ChefSpec::Runner.new do |node|
-      node.set['citadel']['access_key_id'] = 'foo'
-      node.set['citadel']['secret_access_key'] = 'bar'
-      node.set['citadel']['bucket'] = 'fake-s3-bucket'
       node.set['ngrokd']['domain'] = 'example.com'
+      node.set['ngrokd']['source_aws'] = false
     end.converge(described_recipe)
   end
 
@@ -18,12 +16,23 @@ describe 'ngrokd::default' do
     expect(chef_run).to create_directory('/etc/ngrokd')
   end
 
-  it 'creates tls.crt' do
-    expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
-  end
+  context 'tls certs come from AWS-S3' do
+    let(:chef_run) do
+      ChefSpec::Runner.new do |node|
+        node.set['citadel']['access_key_id'] = 'foo'
+        node.set['citadel']['secret_access_key'] = 'bar'
+        node.set['citadel']['bucket'] = 'fake-s3-bucket'
+        node.set['ngrokd']['source_aws'] = true
+      end.converge(described_recipe)
 
-  it 'creates tls.key' do
-    expect(chef_run).to render_file('/etc/ngrokd/tls.key')
+      it 'creates tls.crt' do
+        expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
+      end
+
+      it 'creates tls.key' do
+        expect(chef_run).to render_file('/etc/ngrokd/tls.key')
+      end
+    end
   end
 
   it 'creates ngrokd upstart conf' do
@@ -34,5 +43,4 @@ describe 'ngrokd::default' do
     expect(chef_run).to enable_service('ngrokd')
     expect(chef_run).to start_service('ngrokd')
   end
-
 end

--- a/spec/unit/recipes/install_certs_spec.rb
+++ b/spec/unit/recipes/install_certs_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+describe 'ngrokd-cookbook::install_certs' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['citadel']['access_key_id'] = 'foo'
+      node.set['citadel']['secret_access_key'] = 'bar'
+      node.set['citadel']['bucket'] = 'fake-s3-bucket'
+    end.converge(described_recipe)
+  end
+
+  it 'creates tls.crt' do
+    expect(chef_run).to render_file('/etc/ngrokd/tls.crt')
+  end
+
+  it 'creates tls.key' do
+    expect(chef_run).to render_file('/etc/ngrokd/tls.key')
+  end
+end


### PR DESCRIPTION
Hi Robert,

I refactored your cookbook a little because I didn't want to pull tls certs from AWS, so i put this in a second recipe. 

Tests are passing with Ruby 2.1, but not 1.9.3. `bundle exec rspec` is installing ohai 8.1.1 instead of 8.0.1. I don't have enough Travis/ruby/bundler to figure out why.

I appreciate any help you might be able to give.

Luke Reimer
